### PR TITLE
Use correct class name on installation template

### DIFF
--- a/lib/generators/rails_mini_profiler/templates/rails_mini_profiler.rb.erb
+++ b/lib/generators/rails_mini_profiler/templates/rails_mini_profiler.rb.erb
@@ -6,7 +6,7 @@ RailsMiniProfiler.configure do |config|
   # config.flamegraph_enabled = false
 
   # Use RailsMiniProfiler::Storage::ActiveRecord to store profiles in your Database
-  config.storage = RailsMiniProfiler::Storage::Memory
+  config.storage = RailsMiniProfiler::Storage
 
   # Uncomment to customize how users are detected
   # config.user_provider = proc { |env| Rack::Request.new(env).ip }


### PR DESCRIPTION
This is related to https://github.com/hschne/rails-mini-profiler/issues/4

Maybe a `before :suite` to run the installer before the tests is a good idea to catch installer errors.