### PR TITLE
Add betters support for API only applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,28 @@ rails rails_mini_profiler:install:migrations
 rails db:migrate
 ```
 
+### Support for API-Only Apps
+
+Rails Mini Profiler supports API-only apps, but you have to make some small adjustments to use it. At the top of `application.rb` add [Sprockets](https://github.com/rails/sprockets-rails):
+
+```
+require "sprockets/railtie"
+```
+
+Then, modify `application.rb`:
+
+```
+module ApiOnly
+  class Application < Rails::Application
+    
+    config.api_only = true # Either set this to false
+    config.middleware.use ActionDispatch::Flash # Or add this
+  end
+end
+```
+
+**Note: Sprockets and flash are currently required for some of Rails Mini Profiler's UI features. These modifications may no longer be needed in the future.
+
 ### Flamegraphs are not rendering?
 
 Flamegraphs are loaded into [Speedscope](https://github.com/jlfwong/speedscope) using an Iframe and URI Encoded blobs (see [source](https://github.com/hschne/rails-mini-profiler/blob/main/app/views/rails_mini_profiler/flamegraphs/show.html.erb))

--- a/app/controllers/rails_mini_profiler/application_controller.rb
+++ b/app/controllers/rails_mini_profiler/application_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module RailsMiniProfiler
-  class ApplicationController < ::ApplicationController
+  class ApplicationController < ActionController::Base
     rescue_from ActiveRecord::RecordNotFound, with: :not_found
 
     before_action :check_current_user


### PR DESCRIPTION
With API-only apps there are some things to watch out for: 
- ApplicationController is a `ActionController::API`, which misses `view_context`
- The asset pipeline is disabled per default
- The flash middleware is excluded by default

To fix those: 
- Make the engines `ApplicationController` _not_ inherit from the app controller supplied by the app
- Add some instructions to the Readme on how to make RMP work for API apps