### PR TITLE
Fix NoMethodError (undefined method 'new' for Flamegraph:Module)

### DIFF
--- a/lib/rails_mini_profiler/request_context.rb
+++ b/lib/rails_mini_profiler/request_context.rb
@@ -32,7 +32,7 @@ module RailsMiniProfiler
 
     def save_results!
       ActiveRecord::Base.transaction do
-        profiled_request.flamegraph = Flamegraph.new(data: flamegraph) if flamegraph.present?
+        profiled_request.flamegraph = RailsMiniProfiler::Flamegraph.new(data: flamegraph) if flamegraph.present?
         profiled_request.save
         insert_traces unless traces.empty?
       end


### PR DESCRIPTION
Got the following error when hitting the first request

```ruby
NoMethodError (undefined method `new' for Flamegraph:Module):
```
