### PR TITLE
fix: cast json column to text on PostgreSQL

### DIFF
--- a/app/controllers/rails_mini_profiler/profiled_requests_controller.rb
+++ b/app/controllers/rails_mini_profiler/profiled_requests_controller.rb
@@ -16,7 +16,7 @@ module RailsMiniProfiler
 
     def show
       @traces = @profiled_request.traces
-      @traces = @traces.where('payload LIKE ?', "%#{params[:search]}%") if params[:search]
+      @traces = @traces.where("#{payload_column} LIKE ?", "%#{params[:search]}%") if params[:search]
       @traces = @traces
                   .order(:start)
                   .map { |trace| present(trace, profiled_request: @profiled_request) }
@@ -50,6 +50,15 @@ module RailsMiniProfiler
 
     def configuration
       @configuration ||= RailsMiniProfiler.configuration
+    end
+
+    def payload_column
+      if ActiveRecord::Base.connection.adapter_name == 'PostgreSQL'
+        # Cast json field to text to have access to the LIKE operator
+        'payload:text'
+      else
+        'payload'
+      end
     end
   end
 end

--- a/app/controllers/rails_mini_profiler/profiled_requests_controller.rb
+++ b/app/controllers/rails_mini_profiler/profiled_requests_controller.rb
@@ -55,7 +55,7 @@ module RailsMiniProfiler
     def payload_column
       if ActiveRecord::Base.connection.adapter_name == 'PostgreSQL'
         # Cast json field to text to have access to the LIKE operator
-        'payload:text'
+        'payload::text'
       else
         'payload'
       end

--- a/spec/requests/rails_mini_profiler/profiled_requests_spec.rb
+++ b/spec/requests/rails_mini_profiler/profiled_requests_spec.rb
@@ -30,6 +30,14 @@ module RailsMiniProfiler
 
         expect(response).to be_successful
       end
+
+      it 'with stored item, and search, return successful' do
+        profiled_request = ProfiledRequest.create(user_id: user_id, request_method: 'GET', duration: 0)
+
+        get profiled_request_url(profiled_request.id, search: 'hello')
+
+        expect(response).to be_successful
+      end
     end
 
     describe 'DELETE /destroy' do


### PR DESCRIPTION
With this change, the payload column has access to the LIKE operator.

<details>

I learned things about the conventional commits format, and so on.

---

- [x] Your tests still pass. Run `rake rspec` to verify.
- [x] Your code adheres to the repository code style. Run `rake rubocop` to verify.
- [x] For functional updates, has the documentation been updated accordingly?

</details>