### PR TITLE
Update ui configuration, fix badge config

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,6 @@ Rails Mini Profiler provides a wide array of configuration options. You can find
 | Name                     | Default                      | Description                                                                                     |
 |--------------------------|------------------------------|-------------------------------------------------------------------------------------------------|
 | `enabled`                | `true` (dev)/ `false` (prod) | Whether or not RMP is enabled                                                                   |
-| `badge_enabled`          | `true`                       | Should the hedgehog 🦔 badge be injected into pages?                                             |
-| `badge_position`         | `'top-left'`                 | Where to display the badge. Options are `'top-left', 'top-right', 'bottom-left, 'bottom-right'` |
 | `flamegraph_enabled`     | `true`                       | Should flamegraphs be recorded automatically?                                                   |
 | `flamegraph_sample_rate` | `0.5`                        | The flamegraph sample rate. How many snapshots per millisecond are created.                     |
 | `skip_paths`             | `[]`                         | An array of request paths that should not be profiled. Regex allowed.                           |
@@ -160,9 +158,11 @@ end
 
 Rails Mini Profiler allows you to configure various UI features. 
 
-| Name        | Default | Description                              |
-|-------------|---------|------------------------------------------|
-| `page_size` | `25`    | The page size for lists shown in the UI. |
+| Name             | Default      | Description                                                                                     |
+|------------------|--------------|-------------------------------------------------------------------------------------------------|
+| `badge_enabled`  | `true`       | Should the hedgehog 🦔 badge be injected into pages?                                             |
+| `badge_position` | `'top-left'` | Where to display the badge. Options are `'top-left', 'top-right', 'bottom-left, 'bottom-right'` |
+| `page_size`      | `25`         | The page size for lists shown in the UI.                                                        |
 
 ### Users
 
@@ -224,7 +224,13 @@ As such, compared to `rack-mini-profiler`, it does not support non-Rails apps (e
 
 Rails Mini Profiler is in early development. As such, breaking changes may still be introduced on a regular basis. While Rails Mini Profiler is in pre-release we do not offer upgrade migrations.
 
-If an upgrade to Rails Mini Profiler breaks your application, we recommend that you drop the offending tables and re-run migrations for the latest version: 
+If an upgrade to Rails Mini Profiler breaks your application, we recommend that you clean house and start over. Re-run the initializer and overwrite existing files: 
+
+```bash
+rails rails_mini_profiler:install
+```
+
+If only the DB schema is out of date, drop the offending tables and re-run migrations for the latest version: 
 
 ```
 rails rails_mini_profiler:install:migrations

--- a/lib/generators/rails_mini_profiler/templates/rails_mini_profiler.rb.erb
+++ b/lib/generators/rails_mini_profiler/templates/rails_mini_profiler.rb.erb
@@ -1,10 +1,10 @@
+# Rails Mini Profiler Initializer (<%= RailsMiniProfiler::VERSION %>)
+
+# Customize to your hearts content. If you remove this file, Rails Mini Profiler will use sensible defaults.
+# For more information see https://github.com/hschne/rails-mini-profiler#configuration
 RailsMiniProfiler.configure do |config|
   # Customize when Rails Mini Profiler should run
   config.enabled = proc { |env| Rails.env.development? || env['HTTP_RMP_ENABLED'].present? }
-
-  # Configure how hedgehog badge is rendered
-  config.badge_enabled = true
-  # config.badge_position = 'top-left'
 
   # Configure Flamegraph generation
   config.flamegraph_enabled = true
@@ -20,6 +20,8 @@ RailsMiniProfiler.configure do |config|
   # config.storage.flamegraphs_table = :rmp_flamegraphs
 
   # Configure the Rails Mini Profiler User Interface
+  # config.ui.badge_enabled = true
+  # config.ui.badge_position = 'top-left'
   # config.ui.page_size = 25
 
   # Customize how users are detected

--- a/lib/rails_mini_profiler/badge.rb
+++ b/lib/rails_mini_profiler/badge.rb
@@ -26,6 +26,8 @@ module RailsMiniProfiler
       content_type = @original_response.headers['Content-Type']
       return @original_response unless content_type =~ %r{text/html}
 
+      return @original_response unless @configuration.ui.badge_enabled
+
       modified_response = Rack::Response.new([], @original_response.status, @original_response.headers)
       modified_response.write(modified_body)
       modified_response.finish
@@ -67,7 +69,7 @@ module RailsMiniProfiler
     #
     # @return String The badge position as CSS style
     def css_position
-      case @configuration.badge_position
+      case @configuration.ui.badge_position
       when 'top-right'
         'top: 5px; right: 5px;'
       when 'bottom-left'

--- a/lib/rails_mini_profiler/configuration.rb
+++ b/lib/rails_mini_profiler/configuration.rb
@@ -7,9 +7,6 @@ module RailsMiniProfiler
   #   @return [Logger] the current logger
   # @!attribute enabled
   #   @return [Boolean] if the profiler is enabled
-  # @!attribute badge_position
-  #   @see Badge
-  #   @return [String] the position of the interactive HTML badge.
   # @!attribute flamegraph_enabled
   #   @return [Boolean] if Flamegraph recording is enabled
   # @!attribute flamegraph_sample_rate
@@ -18,14 +15,14 @@ module RailsMiniProfiler
   #   @return [Array<String>] a list of regex patterns for paths to skip
   # @!attribute storage
   #   @return [Storage] the storage configuration
+  # @!attribute ui
+  #   @return [UserInterface] the ui configuration
   # @!attribute user_provider
   #   @return [Proc] a proc to identify a user based on a rack env
   class Configuration
     attr_reader :logger
 
     attr_accessor :enabled,
-                  :badge_enabled,
-                  :badge_position,
                   :flamegraph_enabled,
                   :flamegraph_sample_rate,
                   :skip_paths,
@@ -41,8 +38,6 @@ module RailsMiniProfiler
     # Reset the configuration to default values
     def reset
       @enabled = proc { |_env| Rails.env.development? || Rails.env.test? }
-      @badge_enabled = true
-      @badge_position = 'top-left'
       @flamegraph_enabled = true
       @flamegraph_sample_rate = 0.5
       @logger = RailsMiniProfiler::Logger.new(Rails.logger)

--- a/lib/rails_mini_profiler/configuration/user_interface.rb
+++ b/lib/rails_mini_profiler/configuration/user_interface.rb
@@ -3,6 +3,12 @@
 module RailsMiniProfiler
   # Configure various aspects about Rails Mini Profilers UI.
   #
+  # @!attribute badge_enabled
+  #   @see Badge
+  #   @return [Boolean] if the badge should be enabled
+  # @!attribute badge_position
+  #   @see Badge
+  #   @return [String] the position of the interactive HTML badge
   # @!attribute page_size
   #   @return [Integer] how many items to render per page in list views
   class UserInterface
@@ -23,7 +29,9 @@ module RailsMiniProfiler
       end
     end
 
-    attr_accessor :page_size
+    attr_accessor :badge_enabled,
+                  :badge_position,
+                  :page_size
 
     def initialize(**kwargs)
       defaults!
@@ -32,6 +40,8 @@ module RailsMiniProfiler
 
     # Reset the configuration to default values
     def defaults!
+      @badge_enabled = true
+      @badge_position = 'top-left'
       @page_size = 25
     end
   end

--- a/spec/lib/rails_mini_profiler/badge_spec.rb
+++ b/spec/lib/rails_mini_profiler/badge_spec.rb
@@ -42,6 +42,23 @@ module RailsMiniProfiler
           end
         end
 
+        context 'with badge disabled' do
+          let(:configuration) { Configuration.new(ui: UserInterface.new(badge_enabled: false)) }
+
+          let(:original_response) do
+            OpenStruct.new(
+              status: 200,
+              response: OpenStruct.new(body: '<body>content</body>'),
+              headers: { 'Content-Type' => 'text/html' }
+            )
+          end
+
+          it 'should not inject badge' do
+            new_body = subject.render.response.body
+            expect(new_body).to eq('<body>content</body>')
+          end
+        end
+
         context 'with body tag' do
           let(:original_response) do
             OpenStruct.new(
@@ -51,7 +68,7 @@ module RailsMiniProfiler
             )
           end
 
-          it('should inject badge') do
+          it 'should inject badge' do
             new_body = subject.render.response.body.first
             expect(new_body).to match(/rails-mini-profiler-badge/)
           end


### PR DESCRIPTION
This moves configuration of the badge (`badge_enabled`, `badge_position`) under the `ui` configuration. 

```ruby
config.ui.badge_enabled = false
config.ui.badge_position = 'top-left'
```

Additionally fixes the fact that `badge_enabled` wasn't respected until now. Oops.
