### PR TITLE
Handle non-sprockets apps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Thanks for considering to help make Rails Mini Profiler better! :raised_hands:
 
 ### Setting Up
 
-Create a fork of Rails Mini Profiler and clone your fork locally. Create a new branch for your change, e.g.
+Create a fork of Rails Mini Profiler and clone it locally. Create a new branch for your change, e.g.
 
 ```shell
 git checkout -b add-awesome-new-feature

--- a/lib/rails_mini_profiler/engine.rb
+++ b/lib/rails_mini_profiler/engine.rb
@@ -11,20 +11,24 @@ module RailsMiniProfiler
       app.middleware.use(RailsMiniProfiler::Middleware)
     end
 
-    initializer 'rails_mini_profiler.assets.precompile', group: :all do |app|
-      app.config.assets.precompile += %w[
-        rails_mini_profiler.js
-        rails_mini_profiler/application.css
-        vendor/assets/images
-      ]
-    end
-
     config.generators do |g|
       g.test_framework :rspec
     end
 
     initializer 'rails_mini_profiler_add_static assets' do |app|
       app.middleware.insert_before(ActionDispatch::Static, ActionDispatch::Static, "#{root}/public")
+    end
+
+    # If sprockets is not being used then there is no need to hook into asset compilation. Calling config.assets
+    # without Sprockets installed breaks compilation.
+    if defined?(Sprockets::Rails)
+      initializer 'rails_mini_profiler.assets.precompile', group: :all do |app|
+        app.config.assets.precompile += %w[
+          rails_mini_profiler.js
+          rails_mini_profiler/application.css
+          vendor/assets/images
+        ]
+      end
     end
   end
 end


### PR DESCRIPTION
If the user has an app without sprockets, running `app.config.assets` will result in failure. We now skip this if `Rails::Sprockets` is not defined.