### PR TITLE
fix: do not profile actioncable and asset paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Rails Mini Profiler allows you to configure various UI features.
 | `badge_enabled`     | `true`       | Should the hedgehog 🦔 badge be injected into pages?                                             |
 | `badge_position`    | `'top-left'` | Where to display the badge. Options are `'top-left', 'top-right', 'bottom-left, 'bottom-right'` |
 | `page_size`         | `25`         | The page size for lists shown in the UI.                                                        |
-| `webpacker_enabled` | `true`       | Use Webpacker if enabled? Disable to fall back to the asset pipeline.
+| `webpacker_enabled` | `true`       | Use Webpacker if available? Disable to fall back to the asset pipeline.
 
 
 ### Users

--- a/lib/rails_mini_profiler/guard.rb
+++ b/lib/rails_mini_profiler/guard.rb
@@ -34,12 +34,30 @@ module RailsMiniProfiler
     def ignored_path?
       return true if /#{Engine.routes.find_script_name({})}/.match?(@request.path)
 
-      return true if /assets/.match?(@request.path)
+      return true if asset_path?
+
+      return true if actioncable_request?
 
       ignored_paths = @configuration.skip_paths
       return true if Regexp.union(ignored_paths).match?(@request.path)
 
       false
+    end
+
+    # Is the current request an asset request, e.g. to webpacker packs or assets?
+    #
+    # @return [Boolean] if the request path matches packs or assets
+    def asset_path?
+      %r{^/packs}.match?(@request.path) || %r{^/assets}.match?(@request.path)
+    end
+
+    # Is the current request an actioncable ping
+    #
+    # @return [Boolean] if the request path matches the mount path of actioncable
+    def actioncable_request?
+      return false unless defined?(ActionCable)
+
+      /#{ActionCable.server.config.mount_path}/.match?(@request.path)
     end
 
     # Is the profiler enabled?

--- a/spec/lib/rails_mini_profiler/guard_spec.rb
+++ b/spec/lib/rails_mini_profiler/guard_spec.rb
@@ -17,16 +17,34 @@ module RailsMiniProfiler
         it('should be true') { expect(subject.profile?).to be(true) }
       end
 
+      context 'with no ignored path' do
+        let(:request) { RequestWrapper.new(path: '/ignored') }
+
+        it('should be true') { expect(subject.profile?).to be(true) }
+      end
+
       context 'with profiler mount path' do
         let(:request) { RequestWrapper.new(path: "/#{Engine.routes.find_script_name({})}/1") }
 
         it('should be false') { expect(subject.profile?).to be(false) }
       end
 
-      context 'with no ignored path' do
-        let(:request) { RequestWrapper.new(path: '/ignored') }
+      context 'with pack path' do
+        let(:request) { RequestWrapper.new(path: '/packs/js/abc') }
 
-        it('should be true') { expect(subject.profile?).to be(true) }
+        it('should be false') { expect(subject.profile?).to be(false) }
+      end
+
+      context 'with asset path' do
+        let(:request) { RequestWrapper.new(path: '/assets/images/abc') }
+
+        it('should be false') { expect(subject.profile?).to be(false) }
+      end
+
+      context 'with actioncable path' do
+        let(:request) { RequestWrapper.new(path: ActionCable.server.config.mount_path) }
+
+        it('should be false') { expect(subject.profile?).to be(false) }
       end
 
       context 'with ignored path match' do


### PR DESCRIPTION
This tweaks the default path filtering. Until now, requests to the ActionCable mount point and Webpacker assets were also profiled, which resulted in irrelevant requests being show in the request overview.

See also [this comment](https://github.com/hschne/rails-mini-profiler/issues/55#issuecomment-910950971).
