### PR TITLE
Rework request/response wrappers

### DIFF
--- a/app/models/rails_mini_profiler/profiled_request.rb
+++ b/app/models/rails_mini_profiler/profiled_request.rb
@@ -43,7 +43,7 @@ module RailsMiniProfiler
     def request=(request)
       self.request_body = request.body
       self.request_headers = request.headers
-      self.request_method = request.method
+      self.request_method = request.request_method
       self.request_path = request.path
       self.request_query_string = request.query_string
     end

--- a/lib/rails_mini_profiler/request_context.rb
+++ b/lib/rails_mini_profiler/request_context.rb
@@ -9,7 +9,7 @@ module RailsMiniProfiler
   # @!attribute [r] request
   #   @return [RequestWrapper] the request as sent to the application
   # @!attribute response
-  #   @return [Rack::Response] the response as rendered by the application
+  #   @return [ResponseWrapper] the response as rendered by the application
   # @!attribute profiled_request
   #   @return [ProfiledRequest] the profiling data as gathered during profiling
   # @!attribute traces

--- a/lib/rails_mini_profiler/request_context.rb
+++ b/lib/rails_mini_profiler/request_context.rb
@@ -9,7 +9,7 @@ module RailsMiniProfiler
   # @!attribute [r] request
   #   @return [RequestWrapper] the request as sent to the application
   # @!attribute response
-  #   @return [ResponseWrapper] the response as rendered by the application
+  #   @return [Rack::Response] the response as rendered by the application
   # @!attribute profiled_request
   #   @return [ProfiledRequest] the profiling data as gathered during profiling
   # @!attribute traces
@@ -21,6 +21,8 @@ module RailsMiniProfiler
 
     attr_accessor :response, :profiled_request, :traces, :flamegraph
 
+    # Create a new request context
+    #
     # @param request [RequestWrapper] the request as sent to the application
     def initialize(request)
       @request = request
@@ -58,10 +60,16 @@ module RailsMiniProfiler
       @saved = true
     end
 
+    # Check if the wrapped request has been profiled
+    #
+    # @return [Boolean] true if the wrapped request has been profiled
     def complete?
       @complete
     end
 
+    # Check if profiling results have been saved
+    #
+    # @return [Boolean] true if profiling results have been saved
     def saved?
       @saved
     end

--- a/lib/rails_mini_profiler/request_wrapper.rb
+++ b/lib/rails_mini_profiler/request_wrapper.rb
@@ -1,69 +1,26 @@
 # frozen_string_literal: true
 
 module RailsMiniProfiler
-  # A convenience wrapper around [Rack::Env]
-  #
-  # @!attribute body
-  #   @return [String] the request body
-  # @!attribute method
-  #   @return [String] the request method
-  # @!attribute path
-  #   @return [String] the request path
-  # @!attribute query_string
-  #   @return [String] the request query string
-  # @!attribute env
-  #   @return [Rack::Env] the original env
+  # A convenience wrapper extending {Rack::Request}
   #
   # @api private
-  class RequestWrapper
-    attr_reader :body,
-                :method,
-                :path,
-                :query_string,
-                :env
+  class RequestWrapper < Rack::Request
+    # Convenience method to read the request body as String
+    #
+    # @return [String] the request body
+    def body
+      return '' unless super
 
-    def initialize(*_args, **attributes)
-      @attributes = attributes
-      setup
+      body = super.read
+      super.rewind
+      body
     end
 
     # The request headers
     #
-    # @return [Hash] the headers
+    # @return [Hash] the request headers
     def headers
-      @attributes[:headers] || @env.select { |k, _v| k.start_with? 'HTTP_' } || {}
-    end
-
-    private
-
-    def setup
-      @env = @attributes[:env] || {}
-      @method = setup_method
-      @query_string = setup_query_string
-      @path = setup_path
-      @body = setup_body
-    end
-
-    def setup_method
-      @attributes[:method] || @env['REQUEST_METHOD'] || 'GET'
-    end
-
-    def setup_query_string
-      @attributes[:query_string] || @env['QUERY_STRING'] || ''
-    end
-
-    def setup_path
-      @attributes[:path] || @env['PATH_INFO'] || '/'
-    end
-
-    def setup_body
-      return @attributes[:body] if @attributes[:body]
-
-      return '' unless @env['rack.input']
-
-      body = @env['rack.input'].read
-      @env['rack.input'].rewind
-      body
+      env.select { |k, _v| k.start_with? 'HTTP_' } || {}
     end
   end
 end

--- a/spec/dummy/app/controllers/movies_controller.rb
+++ b/spec/dummy/app/controllers/movies_controller.rb
@@ -18,7 +18,7 @@ class MoviesController < ApplicationController
   def create
     @movie = Movie.new(movie_params)
 
-    if @movie.create
+    if @movie.save
       redirect_to @movie, notice: 'Movie was successfully created.'
     else
       render :new

--- a/spec/lib/rails_mini_profiler/badge_spec.rb
+++ b/spec/lib/rails_mini_profiler/badge_spec.rb
@@ -5,8 +5,9 @@ require 'rails_helper'
 module RailsMiniProfiler
   RSpec.describe Badge do
     describe 'render' do
-      let(:request) { RequestWrapper.new }
-      let(:original_response) { ResponseWrapper.new }
+      let(:env) { {} }
+      let(:request) { RequestWrapper.new(env) }
+      let(:response) { ResponseWrapper.new }
       let(:profiled_request) { ProfiledRequest.new(id: 1) }
       let(:configuration) { Configuration.new }
       let(:request_context) { RequestContext.new(request) }
@@ -20,7 +21,11 @@ module RailsMiniProfiler
 
       context 'with non-html response' do
         let(:original_response) do
-          OpenStruct.new(headers: { 'Content-Type' => 'application/json' })
+          ResponseWrapper.new(
+            'content',
+            200,
+            { 'Content-Type' => 'application/json' }
+          )
         end
 
         it('should return original response') { expect(subject.render).to eq(original_response) }
@@ -28,16 +33,16 @@ module RailsMiniProfiler
 
       context 'with html response' do
         let(:original_response) do
-          OpenStruct.new(
-            status: 200,
-            response: OpenStruct.new(body: 'content'),
-            headers: { 'Content-Type' => 'text/html' }
+          ResponseWrapper.new(
+            'content',
+            200,
+            { 'Content-Type' => 'text/html' }
           )
         end
 
         context 'missing body' do
           it('should return original content') do
-            new_body = subject.render.response.body.first
+            new_body = subject.render.body
             expect(new_body).to eq('content')
           end
         end
@@ -46,30 +51,30 @@ module RailsMiniProfiler
           let(:configuration) { Configuration.new(ui: UserInterface.new(badge_enabled: false)) }
 
           let(:original_response) do
-            OpenStruct.new(
-              status: 200,
-              response: OpenStruct.new(body: '<body>content</body>'),
-              headers: { 'Content-Type' => 'text/html' }
+            ResponseWrapper.new(
+              '<body>content</body>',
+              200,
+              { 'Content-Type' => 'text/html' }
             )
           end
 
           it 'should not inject badge' do
-            new_body = subject.render.response.body
+            new_body = subject.render.body
             expect(new_body).to eq('<body>content</body>')
           end
         end
 
         context 'with body tag' do
           let(:original_response) do
-            OpenStruct.new(
-              status: 200,
-              response: OpenStruct.new(body: '<body>content</body>'),
-              headers: { 'Content-Type' => 'text/html' }
+            ResponseWrapper.new(
+              '<body>content</body>',
+              200,
+              { 'Content-Type' => 'text/html' }
             )
           end
 
           it 'should inject badge' do
-            new_body = subject.render.response.body.first
+            new_body = subject.render.body
             expect(new_body).to match(/rails-mini-profiler-badge/)
           end
         end

--- a/spec/lib/rails_mini_profiler/guard_spec.rb
+++ b/spec/lib/rails_mini_profiler/guard_spec.rb
@@ -5,50 +5,51 @@ require 'rails_helper'
 module RailsMiniProfiler
   RSpec.describe Guard do
     describe 'profile?' do
-      let(:request) { RequestWrapper.new }
+      let(:env) { {} }
+      let(:request) { RequestWrapper.new(env) }
       let(:configuration) { Configuration.new }
       let(:request_context) { RequestContext.new(request) }
 
       subject { Guard.new(request_context, configuration: configuration) }
 
       context 'with path' do
-        let(:request) { RequestWrapper.new(path: '/') }
+        let(:env) { { 'PATH_INFO' => '/' } }
 
         it('should be true') { expect(subject.profile?).to be(true) }
       end
 
       context 'with no ignored path' do
-        let(:request) { RequestWrapper.new(path: '/ignored') }
+        let(:env) { { 'PATH_INFO' => '/ignored' } }
 
         it('should be true') { expect(subject.profile?).to be(true) }
       end
 
       context 'with profiler mount path' do
-        let(:request) { RequestWrapper.new(path: "/#{Engine.routes.find_script_name({})}/1") }
+        let(:env) { { 'PATH_INFO' => "/#{Engine.routes.find_script_name({})}/1" } }
 
         it('should be false') { expect(subject.profile?).to be(false) }
       end
 
       context 'with pack path' do
-        let(:request) { RequestWrapper.new(path: '/packs/js/abc') }
+        let(:env) { { 'PATH_INFO' => '/packs/js/abc' } }
 
         it('should be false') { expect(subject.profile?).to be(false) }
       end
 
       context 'with asset path' do
-        let(:request) { RequestWrapper.new(path: '/assets/images/abc') }
+        let(:env) { { 'PATH_INFO' => '/assets/images/abc' } }
 
         it('should be false') { expect(subject.profile?).to be(false) }
       end
 
       context 'with actioncable path' do
-        let(:request) { RequestWrapper.new(path: ActionCable.server.config.mount_path) }
+        let(:env) { { 'PATH_INFO' => ActionCable.server.config.mount_path } }
 
         it('should be false') { expect(subject.profile?).to be(false) }
       end
 
       context 'with ignored path match' do
-        let(:request) { RequestWrapper.new(path: '/ignored') }
+        let(:env) { { 'PATH_INFO' => '/ignored' } }
 
         it('should be false') do
           configuration.skip_paths = [/ignored/]

--- a/spec/lib/rails_mini_profiler/redirect_spec.rb
+++ b/spec/lib/rails_mini_profiler/redirect_spec.rb
@@ -5,7 +5,8 @@ require 'rails_helper'
 module RailsMiniProfiler
   RSpec.describe Redirect do
     describe 'render' do
-      let(:request) { RequestWrapper.new }
+      let(:env) { {} }
+      let(:request) { RequestWrapper.new(env) }
       let(:configuration) { Configuration.new }
       let(:profiled_request) { ProfiledRequest.new(id: 1) }
       let(:request_context) { RequestContext.new(request) }
@@ -15,7 +16,7 @@ module RailsMiniProfiler
       before(:each) { request_context.profiled_request = profiled_request }
 
       context 'with flamegraph parameter' do
-        let(:request) { RequestWrapper.new(query_string: 'rmp_flamegraph=true') }
+        let(:env) { { 'QUERY_STRING' => 'rmp_flamegraph=true' } }
 
         it('should redirect to flamegraph path') do
           expect(subject.render.first).to eq(302)

--- a/spec/models/rails_mini_profiler/profiled_request_spec.rb
+++ b/spec/models/rails_mini_profiler/profiled_request_spec.rb
@@ -5,15 +5,17 @@ require 'rails_helper'
 module RailsMiniProfiler
   RSpec.describe ProfiledRequest, type: :model do
     describe 'request' do
-      let(:request_wrapper) do
-        RequestWrapper.new(
-          body: 'body',
-          headers: { header: 'value' },
-          method: 'GET',
-          path: '/path',
-          query_string: 'query'
-        )
+      let(:env) do
+        {
+          'rack.input' => StringIO.new('body'),
+          'REQUEST_METHOD' => 'GET',
+          'PATH_INFO' => '/path',
+          'QUERY_STRING' => 'query',
+          'HTTP_SAMPLE_HEADER' => 'value'
+        }
       end
+
+      let(:request_wrapper) { RequestWrapper.new(env) }
 
       before(:each) do
         subject.request = request_wrapper
@@ -24,7 +26,7 @@ module RailsMiniProfiler
       end
 
       it 'sets request headers' do
-        expect(subject.request_headers).to eq({ 'header' => 'value' })
+        expect(subject.request_headers).to eq({ 'HTTP_SAMPLE_HEADER' => 'value' })
       end
 
       it 'sets request method' do
@@ -41,17 +43,19 @@ module RailsMiniProfiler
     end
 
     describe 'response' do
-      let(:response_wrapper) do
-        OpenStruct.new(
-          body: 'body',
-          media_type: 'application/json',
-          headers: { header: 'value' },
-          status: 200
+      let(:response) do
+        ResponseWrapper.new(
+          'body',
+          200,
+          {
+            'HTTP_HEADER' => 'header',
+            'Content-Type' => 'application/json'
+          }
         )
       end
 
       before(:each) do
-        subject.response = response_wrapper
+        subject.response = response
       end
 
       it 'sets response body' do
@@ -63,7 +67,7 @@ module RailsMiniProfiler
       end
 
       it 'sets response headers' do
-        expect(subject.response_headers).to eq({ 'header' => 'value' })
+        expect(subject.response_headers).to eq({ 'HTTP_HEADER' => 'header', 'Content-Type' => 'application/json' })
       end
 
       it 'sets response status' do

--- a/spec/requests/rails_mini_profiler/application_spec.rb
+++ b/spec/requests/rails_mini_profiler/application_spec.rb
@@ -6,13 +6,50 @@ module RailsMiniProfiler
   RSpec.describe 'Application', type: :request do
     after(:each) { User.current_user = nil }
 
-    describe 'GET /index' do
-      it 'creates a profiled request' do
-        get movies_url(1)
+    describe 'POST /movie' do
+      it 'creates a profiled request ' do
+        post(movies_url, params: { movie: { title: 'name' } })
 
-        expect(response).to be_successful
+        expect(response).to be_redirect
 
-        expect(ProfiledRequest.exists?(request_path: '/movies.1')).to be(true)
+        expect(ProfiledRequest.exists?(request_path: '/movies')).to be(true)
+      end
+
+      it 'saves request data' do
+        post(movies_url, params: { movie: { title: 'name' } })
+
+        expect(response).to be_redirect
+
+        profiled_request = ProfiledRequest.find_by(request_path: '/movies')
+        expect(profiled_request.request_method).to eq('POST')
+        expect(profiled_request.request_query_string).to eq('')
+        expect(profiled_request.request_body).to eq('movie[title]=name')
+        expect(profiled_request.request_headers)
+          .to eq({ 'HTTP_HOST' => 'www.example.com', 'HTTP_ACCEPT' => 'application/json', 'HTTP_COOKIE' => '' })
+      end
+
+      it 'saves performance data' do
+        post(movies_url, params: { movie: { title: 'name' } })
+
+        expect(response).to be_redirect
+
+        profiled_request = ProfiledRequest.find_by(request_path: '/movies')
+        expect(profiled_request.start).to be >= 0
+        expect(profiled_request.finish).to be >= 0
+        expect(profiled_request.duration).to be >= 0
+        expect(profiled_request.allocations).to be >= 0
+      end
+
+      it 'saves response data' do
+        post(movies_url, params: { movie: { title: 'name' } })
+
+        expect(response).to be_redirect
+
+        profiled_request = ProfiledRequest.find_by(request_path: '/movies')
+        expect(profiled_request.response_status).to eq(302)
+        expect(profiled_request.response_body).to match('You are being')
+        expect(profiled_request.response_headers['Content-Type']).to eq('text/html; charset=utf-8')
+        expect(profiled_request.response_media_type).to eq('text/html')
       end
     end
 


### PR DESCRIPTION
This fixes #85. 

Rather than wrapping `Rack::Request` and `Rack::Response` we now inherit. Makes things more robust and slightly less verbose. We need to keep wrappers around for convenience reasons still however, e.g. to extract the body of a response as string.

Other cleanup: 
- More documentation
- More tests

