### PR TITLE
fix: improve robustness when saving profiled requests,

### DIFF
--- a/lib/rails_mini_profiler/middleware.rb
+++ b/lib/rails_mini_profiler/middleware.rb
@@ -15,7 +15,6 @@ module RailsMiniProfiler
       request_context = RequestContext.new(request)
       return @app.call(env) unless Guard.new(request_context).profile?
 
-      request_context.profiled_request = ProfiledRequest.new
       result = with_tracing(request_context) { profile(request_context) }
       return result unless request_context.authorized?
 
@@ -45,7 +44,6 @@ module RailsMiniProfiler
     private
 
     def complete!(request_context)
-      request_context.complete_profiling!
       request_context.save_results!
       true
     rescue ActiveRecord::ActiveRecordError => e

--- a/lib/rails_mini_profiler/request_context.rb
+++ b/lib/rails_mini_profiler/request_context.rb
@@ -10,6 +10,8 @@ module RailsMiniProfiler
   #   @return [RequestWrapper] the request as sent to the application
   # @!attribute response
   #   @return [ResponseWrapper] the response as rendered by the application
+  #   # @!attribute profiled_request
+  #   @return [ProfiledRequest] the profiling data as gathered during profiling
   # @!attribute traces
   #   @return [Array<Models::Trace>] trace wrappers gathered during profiling
   # @!attribute flamegraph


### PR DESCRIPTION
This fixes #86. 

If the DB has not been set up properly, performing `ProfiledRequest.new` outside of the DB catch block results in errors. 

We can avoid opening a connection too early by moving the creation of a new profiled request to later in the middleware. `RequestContext` keeps the execution state and acts as a builder to create the request when needed.