### PR TITLE
Add utf8 charset explicitly to table definitions

### DIFF
--- a/db/migrate/20210621185018_create_rmp.rb
+++ b/db/migrate/20210621185018_create_rmp.rb
@@ -2,7 +2,7 @@
 
 class CreateRmp < ActiveRecord::Migration[6.0]
   def change
-    create_table :rmp_profiled_requests do |t|
+    create_table :rmp_profiled_requests, charset: 'utf8' do |t|
       t.string :user_id
       t.bigint :start
       t.bigint :finish
@@ -23,7 +23,7 @@ class CreateRmp < ActiveRecord::Migration[6.0]
       t.index :created_at
     end
 
-    create_table :rmp_traces do |t|
+    create_table :rmp_traces, charset: 'utf8' do |t|
       t.belongs_to :rmp_profiled_request, null: false, foreign_key: true
       t.string :name
       t.bigint :start
@@ -36,7 +36,7 @@ class CreateRmp < ActiveRecord::Migration[6.0]
       t.timestamps
     end
 
-    create_table :rmp_flamegraphs do |t|
+    create_table :rmp_flamegraphs, charset: 'utf8' do |t|
       t.belongs_to :rmp_profiled_request, null: false, foreign_key: true
       t.binary :data
 


### PR DESCRIPTION
For any databases that do not have utf8 as the default. Without this
setting the tables are created with the default, but are treated as
utf8, which can result in errors:

 `ERROR 1366 (HY000): Incorrect string value: '\xE2\x84\xAF\x0A -...' for column 'response_body' at row 1`

This came up in the context of a legacy MySQL application. 
The kind of project where this project is exceedingly useful!

----

Before submitting, please review the [contributor guidelines](/CONTRIBUTING.md). In particular:

- [x] Your tests pass on all supported Rails versions. Run `bin/appraisal rspec` to verify.
- [x] Your code adheres to the repository code style. Run `bin/rake lint` to verify.
- [N/A] For functional updates, has the documentation been updated accordingly?

