### PR TITLE
Sanitize response body with null bytes

### DIFF
--- a/app/models/rails_mini_profiler/profiled_request.rb
+++ b/app/models/rails_mini_profiler/profiled_request.rb
@@ -67,10 +67,16 @@ module RailsMiniProfiler
     private
 
     def sanitize
+      # When tracing requests that send or receive files which contain null bytes - or any body with null bytes - saving
+      # the request to Postgres will fail. So we sanitize request/response body first.
       self.request_body ||= ''
       self.request_body = request_body
                             .encode('UTF-8', invalid: :replace, undef: :replace)
                             .delete("\000")
+      self.response_body ||= ''
+      self.response_body = response_body
+                             .encode('UTF-8', invalid: :replace, undef: :replace)
+                             .delete("\000")
     end
   end
 end

--- a/spec/models/rails_mini_profiler/profiled_request_spec.rb
+++ b/spec/models/rails_mini_profiler/profiled_request_spec.rb
@@ -5,11 +5,18 @@ require 'rails_helper'
 module RailsMiniProfiler
   RSpec.describe ProfiledRequest, type: :model do
     describe 'save' do
-      it 'removes body null bytes' do
+      it 'removes request body null bytes' do
         request = ProfiledRequest.new(request_body: "content\000")
         request.save
 
         expect(request.request_body).to eq('content')
+      end
+
+      it 'removes response body null bytes' do
+        request = ProfiledRequest.new(response_body: "content\000")
+        request.save
+
+        expect(request.response_body).to eq('content')
       end
     end
 


### PR DESCRIPTION
This fixes #177, which was overlooked in the fix for #157. 

Both request and response bodies may contain null bytes (e.g. when sending or receiving files) and storing those requests
in Postgres will result in `ArgumentError`. So we remove the null bytes before saving.